### PR TITLE
Improve display information for significance and update version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "falidex",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "author": "Usiko",
   "homepage": "/",
   "scripts": {

--- a/src/app/components/block/list/signification/list/signification-block-item-list.component.html
+++ b/src/app/components/block/list/signification/list/signification-block-item-list.component.html
@@ -11,9 +11,9 @@
 <ng-template #content>
     <ion-label>
         <div>
-            <div class="text-title">{{item().name}}</div>
+            <div class="text-title">{{item().content}}</div>
         </div>
-        @let links = item().links|filterLink:['placement','position', 'symbolsens','symbols']:true;
+        @let links = displayLinks()|filterLink:['placement','position', 'symbolsens','symbols']:true;
         @if(links) {
             @for(link of links; track link) {
                 <ng-container *ngTemplateOutlet="linkTpl;context:{link:link}"></ng-container>
@@ -26,20 +26,11 @@
         <div class="title">
 
             <div>
-                @if(link.position) {
-                    <span class="subtitle">{{link.position.name}}</span>
-                }
-                {{(link.position && link.symbols)?', ':''}}
-                @if(link.symbols) {
-                    <span class="subtitle">{{link.symbols.name}}</span>
-                }
-                {{((link.symbol || link.position)&& link.symbolsens)?', ':''}}
-                @if(link.symbolsens) {
-                    <span class="subtitle">{{link.symbolsens.name}}</span>
-                }
-                {{((link.symbol || link.position ||link.symbolsens ) && link.placement)?', ':''}}
+                {{link.displayInfo}}
                 @if(link.placement) {
-                    décernm. <span class="subtitle">{{link.placement.name}}</span>
+                    <div class="decernement">
+                        décernement <span class="subtitle">{{link.placement.name}}</span>
+                    </div>
                 }
             </div>
 

--- a/src/app/components/block/list/signification/list/signification-block-item-list.component.scss
+++ b/src/app/components/block/list/signification/list/signification-block-item-list.component.scss
@@ -29,7 +29,19 @@ ion-item {
             margin-left: 5px;
         }
     }
+    .decernement{
+        color: var(--ion-color-dark-tint);
+        margin-top: 15px;
+        font-style: italic;
+    }
     .text-title {
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        width: 100%;
+        overflow: hidden;
+        margin-bottom: 5px;
+        font-size: 0.9em;
+
         &::first-letter {
             text-transform: uppercase;
         }

--- a/src/app/components/block/list/signification/list/signification-block-item-list.component.ts
+++ b/src/app/components/block/list/signification/list/signification-block-item-list.component.ts
@@ -1,10 +1,13 @@
-import { Component, input, output } from '@angular/core';
-import { ISignification } from 'src/app/models/linked-data-models';
+import { Component, computed, input, output } from '@angular/core';
+import { ICollectionLink, ISignification } from 'src/app/models/linked-data-models';
 import { IonItem, IonLabel } from "@ionic/angular/standalone";
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { FaIconComponent } from "@fortawesome/angular-fontawesome";
 import { FilterLinkPipe } from 'src/app/components/shared/pipes/filter-links.pipe';
+interface IDisplay extends ICollectionLink  { 
+    displayInfo:string
+}
 
 @Component({
     selector: 'app-signification-block-item-list',
@@ -14,6 +17,32 @@ import { FilterLinkPipe } from 'src/app/components/shared/pipes/filter-links.pip
 })
 export class SignificationBlockItemListComponent {
     item = input.required<ISignification>();
+    displayLinks = computed<IDisplay[]>(()=>{
+    const signification  = this.item()
+    return signification.links.map(link=>{
+        let displaylinks:string[] = [];
+        if(link.symbols?.name)
+        {
+            displaylinks.push(link.symbols?.name)
+        }
+        if(link.symbolsens?.name)
+        {
+            displaylinks.push(link.symbolsens?.name)
+        }
+        if(link.position?.name)
+        {
+            displaylinks.push(link.position?.name)
+        }
+        if(link.symboleAccessory?.name)
+        {
+            displaylinks.push(link.symboleAccessory?.name)
+        }
+        return {
+            ...link,
+            displayInfo:displaylinks.join(', '),
+        }
+    });
+})
 
     /**
      * show navigation arrow

--- a/src/app/components/block/list/signification/signification-item-block/signification-item-block.component.html
+++ b/src/app/components/block/list/signification/signification-item-block/signification-item-block.component.html
@@ -6,7 +6,7 @@
             <div class="text-content">{{signification().content}}</div>
             }
         </div>
-        @let links = signification().links|filterLink:['placement','position', 'symbolsens','symbols']:true;
+        @let links = displayLinks()|filterLink:['placement','position', 'symbolsens','symbols']:true;
         @if(links) {
             @for(link of links; track link) {
                 <ng-container *ngTemplateOutlet="linkTpl;context:{link:link}"></ng-container>
@@ -17,17 +17,7 @@
 <ng-template #linkTpl let-link="link">
     <div class="metaInfo">
         <div class="title">
-            @if(link.placement) {
-                décernement <span class="subtitle">{{link.placement.name}}</span>
-            }
-            {{(link.placement && link.position)?' ,':''}}
-            @if(link.position) {
-                <span class="subtitle">{{link.position.name}}</span>
-            }
-            {{(link.placement && link.symbolsens)?' ,':''}}
-            @if(link.symbolsens) {
-                <span class="subtitle">{{link.symbolsens.name}}</span>
-            }
+            {{link.displayInfo}}
             @if(link.spe) {
             <fa-icon class="primary-color" [icon]="['fas', 'star']"></fa-icon>
             }
@@ -35,5 +25,10 @@
                 <fa-icon class="primary-color" [icon]="['fas', 'circle-exclamation']"></fa-icon>
             }
         </div>
+    </div>
+    <div class="bottom">
+         @if(link.placement) {
+                décernement {{link.placement.name}}
+            }
     </div>
 </ng-template>

--- a/src/app/components/block/list/signification/signification-item-block/signification-item-block.component.scss
+++ b/src/app/components/block/list/signification/signification-item-block/signification-item-block.component.scss
@@ -41,7 +41,6 @@ ion-item {
         font-size: 0.7em;
         font-style: italic;
         text-align: center;
-        width: 100%;
         margin-top: 15px;
         &::first-letter {
             text-transform: uppercase;

--- a/src/app/components/block/list/signification/signification-item-block/signification-item-block.component.scss
+++ b/src/app/components/block/list/signification/signification-item-block/signification-item-block.component.scss
@@ -34,6 +34,20 @@ ion-item {
             margin-left: 5px;
         }
     }
+    .bottom {
+       
+        color: var(--ion-color-dark-tint);
+        width: 100%;
+        font-size: 0.7em;
+        font-style: italic;
+        text-align: center;
+        width: 100%;
+        margin-top: 15px;
+        &::first-letter {
+            text-transform: uppercase;
+        }
+    }
+    
     .text-content {
         font-size: 0.9em;
         font-style: italic;

--- a/src/app/components/block/list/signification/signification-item-block/signification-item-block.component.ts
+++ b/src/app/components/block/list/signification/signification-item-block/signification-item-block.component.ts
@@ -1,9 +1,13 @@
-import { Component, input } from '@angular/core';
-import { ISignification } from 'src/app/models/linked-data-models';
+import { Component, computed, input } from '@angular/core';
+import { ICollectionLink, ISignification } from 'src/app/models/linked-data-models';
 import { IonItem, IonLabel } from "@ionic/angular/standalone";
 import { FaIconComponent } from "@fortawesome/angular-fontawesome";
 import { CommonModule } from '@angular/common';
 import { FilterLinkPipe } from 'src/app/components/shared/pipes/filter-links.pipe';
+
+interface IDisplay extends ICollectionLink  { 
+    displayInfo:string
+}
 
 
 @Component({
@@ -14,6 +18,29 @@ import { FilterLinkPipe } from 'src/app/components/shared/pipes/filter-links.pip
 })
 export class SignificationItemBlockComponent {
     signification = input.required<ISignification>();
+
+    displayLinks = computed<IDisplay[]>(()=>{
+        const signification  = this.signification()
+        return signification.links.map(link=>{
+            let displaylinks:string[] = [];
+            if(link.symbolsens?.name)
+            {
+                displaylinks.push(link.symbolsens?.name)
+            }
+            if(link.position?.name)
+            {
+                displaylinks.push(link.position?.name)
+            }
+            if(link.symboleAccessory?.name)
+            {
+                displaylinks.push(link.symboleAccessory?.name)
+            }
+            return {
+                ...link,
+                displayInfo:displaylinks.join(', '),
+            }
+        });
+    })
 
     constructor() { }
 }

--- a/src/app/components/block/list/symbol-item/list/symbole-block-item-list.component.html
+++ b/src/app/components/block/list/symbol-item/list/symbole-block-item-list.component.html
@@ -61,37 +61,17 @@
         @if(significations) {
             @if(significations.length>0) {
             <p class="signification">
-                @if(significations.length>2) {
+                @if(significations.length>1) {
+
                     <div class="content">
                         <div class="flex">
-                            @if(significations[0].spe && showSpe()) {
-                                <fa-icon class="primary-color" [icon]="['fas', 'star']"></fa-icon>
-                            }
-                            @if(significations[0].blame===true) {
-                                <fa-icon class="primary-color" [icon]="['fas', 'circle-exclamation']"></fa-icon>
-                            }
                             <div>
-                                @if(significations[0].placement) {
-                                    dec. {{significations[0].placement.name}}: 
-                                }
-                                @if(significations[0].symbolsens) {
-                                    , {{significations[0].symbolsens.name}},
-                                }
-                                {{significations[0].signification?.content}}
+                                {{significations.length}} significations
                             </div>
-
-
                         </div>
                     </div>
-                    <span class="content">
-                        <div class="flex">
-                            <div>
-                                Et {{significations.length-1}} autres significations
-                            </div>
-                        </div>
-                    </span>
                 }
-                @if(significations.length<=2) {
+                @else if(significations.length==1) {
                     @for(signification of significations; track signification) {
                     <div class="content">
                         <div class="flex">
@@ -103,9 +83,11 @@
                             }
                             <div>
                                 @if(signification.placement) {
-                                     dec. {{signification.placement.name}}: 
                                     @if(signification.symbolsens) {
-                                        , {{signification.symbolsens.name}},
+                                        {{signification.symbolsens.name}},
+                                    }
+                                    @if(signification.symboleAccessory) {
+                                        {{signification.symboleAccessory.name}},
                                     }
                                 }
                                 {{signification.signification?.content}}


### PR DESCRIPTION
This pull request refactors how signification links are displayed in both list and block components to improve clarity and maintainability. The main changes include introducing a computed property to generate a concise `displayInfo` string for each link, updating templates to use this new property, and improving the visual presentation for placement information. Additionally, minor adjustments were made to how significations are summarized in symbol item lists.

**Refactoring and Data Handling:**

* Added a computed `displayLinks` property in both `SignificationBlockItemListComponent` and `SignificationItemBlockComponent`, generating a `displayInfo` string for each link by concatenating relevant fields. Introduced the `IDisplay` interface to include this new property. [[1]](diffhunk://#diff-7494c28a3833bfd1fe645051eed6b288d5dfd167e4764ea273cf7f2d161b346bL1-R10) [[2]](diffhunk://#diff-7494c28a3833bfd1fe645051eed6b288d5dfd167e4764ea273cf7f2d161b346bR20-R45) [[3]](diffhunk://#diff-5349b8d44c8095eb691bbacc03b0d0c8e3d828eda4118df7a0fe09d8d913f440L1-R11) [[4]](diffhunk://#diff-5349b8d44c8095eb691bbacc03b0d0c8e3d828eda4118df7a0fe09d8d913f440R22-R44)

**Template and UI Improvements:**

* Updated templates in `signification-block-item-list.component.html` and `signification-item-block.component.html` to use `displayLinks` and display `link.displayInfo` instead of manually constructing strings inline. Placement information is now shown in a visually distinct manner. [[1]](diffhunk://#diff-d79845fc63ad79af76eab4efc8b77728d239041ab016e2c21e6770e4b194b8fcL14-R16) [[2]](diffhunk://#diff-d79845fc63ad79af76eab4efc8b77728d239041ab016e2c21e6770e4b194b8fcL29-R33) [[3]](diffhunk://#diff-402339649e090617262da820e2221e688a01182f4891cd5b8b6bd935c8062494L9-R9) [[4]](diffhunk://#diff-402339649e090617262da820e2221e688a01182f4891cd5b8b6bd935c8062494L20-R20) [[5]](diffhunk://#diff-402339649e090617262da820e2221e688a01182f4891cd5b8b6bd935c8062494R29-R33)

* Enhanced styling for placement ("décernement") and title elements in both components for better readability and consistency. [[1]](diffhunk://#diff-bfb42fe59af2a09531d3cfd37fcea15928c10001c27ce6ce86c4d9cccdedf1e6R32-R44) [[2]](diffhunk://#diff-ab182ee1c2e736711b57b4330c8c4926e2c23dac1b6eb5e65d634f7fbacd5dd6R37-R50)

**Signification Summary Logic:**

* Simplified the logic for displaying multiple significations in `symbole-block-item-list.component.html`, now showing a summary count when there is more than one signification and adjusting how accessory and sense information is displayed. [[1]](diffhunk://#diff-8ed84817528594ec9e7cda9acf99a6f626c08fcf47488d65fd8c27dc72997114L64-R74) [[2]](diffhunk://#diff-8ed84817528594ec9e7cda9acf99a6f626c08fcf47488d65fd8c27dc72997114L106-R90)

**Miscellaneous:**

* Bumped the package version from `0.4.4` to `0.4.5` in `package.json`.